### PR TITLE
fix(ci): allow unrs-resolver build scripts in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Root cause
pnpm 11 blocks build scripts by default unless explicitly allowed via `allowBuilds` in `pnpm-workspace.yaml`. `unrs-resolver@1.12.2` (transitive dependency) was blocked, causing `pnpm install --frozen-lockfile` to exit 1 with `ERR_PNPM_IGNORED_BUILDS`.

## Fix
Add `unrs-resolver: true` to the existing `allowBuilds` map in `pnpm-workspace.yaml`.

## Diff
One-line change in `pnpm-workspace.yaml`.